### PR TITLE
Datapath: update to expose segment and pinning information

### DIFF
--- a/cornflakes-libos/Cargo.toml
+++ b/cornflakes-libos/Cargo.toml
@@ -30,6 +30,7 @@ itertools = "0.10.2"
 bitmaps = "3.2.0"
 bumpalo = { git = "https://github.com/deeptir18/bumpalo", features = ["collections"] }
 ahash = "0.7.6"
+zero_copy_cache = { git = "https://github.com/vishwanath1306/zero_copy_cache" }
 
 [dev-dependencies]
 libc = "0.2.81"

--- a/dpdk-datapath/src/datapath/allocator.rs
+++ b/dpdk-datapath/src/datapath/allocator.rs
@@ -246,6 +246,12 @@ impl DatapathMemoryPool for MempoolInfo {
         true
     }
 
+    fn get_pagesize(&self) -> usize {
+        // TODO: how do we properly detect the pagesize?
+        // For now, just return pgsize 2mb
+        cornflakes_libos::mem::PGSIZE_2MB
+    }
+
     fn has_allocated(&self) -> bool {
         unimplemented!();
     }

--- a/mlx5-datapath/Cargo.toml
+++ b/mlx5-datapath/Cargo.toml
@@ -18,6 +18,7 @@ hashbrown = "0.11.*"
 bytes = "1.1.0"
 byteorder = "1.3.4"
 protobuf = "3.0.3"
+zero_copy_cache = { git = "https://github.com/vishwanath1306/zero_copy_cache" }
 
 [build-dependencies]
 bindgen = "0.60.1" 

--- a/mlx5-datapath/src/datapath/allocator.rs
+++ b/mlx5-datapath/src/datapath/allocator.rs
@@ -205,6 +205,14 @@ impl DatapathMemoryPool for DataMempool {
         }
     }
 
+    #[inline]
+    fn get_pagesize(&self) -> usize {
+        unsafe {
+            let data_mempool = self.get_data_mempool();
+            access!(data_mempool, pgsize, usize)
+        }
+    }
+
     #[inline(always)]
     fn has_allocated(&self) -> bool {
         unsafe { access!(get_data_mempool(self.mempool()), allocated, usize) >= 1 }

--- a/mlx5-datapath/src/datapath/connection.rs
+++ b/mlx5-datapath/src/datapath/connection.rs
@@ -4958,6 +4958,17 @@ impl Datapath for Mlx5Connection {
         self.allocator.recover_buffer(buf)
     }
 
+    #[inline]
+    fn recover_metadata_with_status(
+        &self,
+        buf: &[u8],
+    ) -> Result<cornflakes_libos::datapath::MetadataStatus<Self>>
+    where
+        Self: Sized,
+    {
+        self.allocator.recover_buffer_with_segment_info(buf)
+    }
+
     fn add_memory_pool(&mut self, size: usize, min_elts: usize) -> Result<Vec<MempoolID>> {
         // use 2MB pages for data, 2MB pages for metadata (?)
         let actual_size = cornflakes_libos::allocator::align_to_pow2(size);


### PR DESCRIPTION
This commit imports ZeroCopyCache, defines a segment object to use with ZeroCopyCache, and adds a datapath recovery function that returns metadata along with associated segment information.